### PR TITLE
Add  xgcm Notebook to TOC

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -7,3 +7,4 @@ parts:
   - caption: Basic Concepts
     chapters:
       - file: notebooks/xarray_intro.ipynb
+      - file: notebooks/xgcm_intro.ipynb


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #8 
 - [x] New notebooks are added to `_toc.yml` and show up properly in website preview.
 
I checked a local preview of the site and the xgcm notebook now shows properly. 

<img width="1233" alt="image" src="https://github.com/m2lines/data-gallery/assets/14314623/e43d7b7a-87f9-4f69-96ec-c819c7b726b2">

