### PR TITLE
Add pre-commit badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/m2lines/data-gallery/main.svg)](https://results.pre-commit.ci/latest/github/m2lines/data-gallery/main)
+
 # data-gallery
 
 ## Installation


### PR DESCRIPTION
I activated the [pre-commit.ci github app](https://results.pre-commit.ci/repo/github/715306346) to run pre-commit checks as part of our status checks.

From now on every PR will show  this
<img width="720" alt="image" src="https://github.com/m2lines/data-gallery/assets/14314623/0c87a542-517b-4073-a355-7e45bd0ad626">

This will also submit PRs to autofix issues! 