### PR TITLE
Removed notebook that requires data from leaphub

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -13,7 +13,7 @@ only_build_toc_files: true
 execute:
   execute_notebooks: force
   timeout: 1800
-  exclude_patterns: ['*old_notebooks/*', '*notebooks/OM4_SE_animation.ipynb', '*notebooks/unet_movie.ipynb']
+  exclude_patterns: ['*old_notebooks/*', '*notebooks/OM4_SE_animation.ipynb']
 
 parse:
   myst_enable_extensions:


### PR DESCRIPTION
This is a draft PR that tests whether the notebooks that require data from leaphub can be executed by the service account. Currently, there are two notebooks that require data from leaphub. Unfortunately, one of them cannot be executed within a reasonable amount of time due to issue #23. I have removed the other one for testing. 
@jbusecke 

 - [x] Closes #49
